### PR TITLE
ofdpa.proto: expose ofdpaRxRateSet()

### DIFF
--- a/api/ofdpa.proto
+++ b/api/ofdpa.proto
@@ -89,6 +89,8 @@ service OfdpaRpc {
 
   rpc ofdpaPortTrunkGroupSet(TrunkGroupSet) returns (OfdpaStatus) {}
   rpc ofdpaTrunkPortMemberActiveSet(PortMemberActiveSet) returns (OfdpaStatus) {}
+
+  rpc ofdpaRxRateSet(Pps) returns (OfdpaStatus) {}
 }
 
 message Empty {}
@@ -435,3 +437,6 @@ message StgId {
   uint32 id = 1;
 }
 
+message Pps {
+  sint32 pps = 1;
+}


### PR DESCRIPTION
Sync ofdpa.proto with latest changes from ofdpa-grpc and add ofdpaRxRateSet().

"depends" on https://github.com/bisdn/meta-ofdpa/pull/90