### PR TITLE
ofdapa.proto: add port KNET helpers

### DIFF
--- a/api/ofdpa.proto
+++ b/api/ofdpa.proto
@@ -90,6 +90,9 @@ service OfdpaRpc {
   rpc ofdpaPortTrunkGroupSet(TrunkGroupSet) returns (OfdpaStatus) {}
   rpc ofdpaTrunkPortMemberActiveSet(PortMemberActiveSet) returns (OfdpaStatus) {}
 
+  rpc ofdpaPortKnetCreate(PortNum) returns (OfdpaStatus) {}
+  rpc ofdpaPortKnetDelete(PortNum) returns (OfdpaStatus) {}
+
   rpc ofdpaRxRateSet(Pps) returns (OfdpaStatus) {}
 }
 


### PR DESCRIPTION
Sync ofdpa.proto with ofdpa-grpc 0.9 and add port KNET helpers.

Depends on https://github.com/bisdn/meta-ofdpa/pull/99.